### PR TITLE
Copy docstring from original class to decorated class to ensure compa…

### DIFF
--- a/singleton_decorator/decorator.py
+++ b/singleton_decorator/decorator.py
@@ -5,6 +5,7 @@ class _SingletonWrapper:
     """
 
     def __init__(self, cls):
+        self.__doc__ = getattr(cls, '__doc__', None)
         self.__wrapped__ = cls
         self._instance = None
 


### PR DESCRIPTION
When decorating a class with the singleton decorator, the [`sphinx`](https://www.sphinx-doc.org/en/master/index.html) module cannot automatically generate the documentation from the wrapped class since the docstring is lost.

Copying the docstring in the `__init__` method takes care of that problem.